### PR TITLE
Make compatible with new React version 16 and add character count for…

### DIFF
--- a/src/react-textarea-count.jsx
+++ b/src/react-textarea-count.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Textarea extends Component {
   static propTypes = {
@@ -26,13 +27,19 @@ export default class Textarea extends Component {
 
   renderCount() {
     const { countLimit } = this.props;
-    const className = `textarea__count${this.textarea && countLimit && this.textarea.value.length > countLimit ? ' textarea__count--error' : ''}`;
+    const className = `textarea__count${this.textarea && countLimit && this.textarea.value.length >= countLimit ? ' textarea__count--error' : ''}`;
 
     return (
       <span className={className}>
         {this.state.count}{countLimit > 0 && `/${countLimit}`}
       </span>
     );
+  }
+
+  componentDidMount() {
+    this.setState({
+      count: this.textarea.value.length,
+    });
   }
 
   render() {


### PR DESCRIPTION
This package wasn't unusable with React 16 removed deprecation of React.PropTypes
https://github.com/facebook/react/blob/master/CHANGELOG.md#removed-deprecations